### PR TITLE
White Space in Slugs, Display Columns from Notion

### DIFF
--- a/webapp/app/components/NotionPageDetails.tsx
+++ b/webapp/app/components/NotionPageDetails.tsx
@@ -20,8 +20,8 @@ import type {
   // DividerBlockObjectResponse,
   // BreadcrumbBlockObjectResponse,
   // TableOfContentsBlockObjectResponse,
-  // ColumnListBlockObjectResponse,
-  // ColumnBlockObjectResponse,
+  ColumnListBlockObjectResponse,
+  ColumnBlockObjectResponse,
   // LinkToPageBlockObjectResponse,
   // TableBlockObjectResponse,
   // TableRowBlockObjectResponse,
@@ -57,6 +57,10 @@ export function NotionPageDetails({
         return <Image key={detail.id} detail={detail} />;
       case "video":
         return <Video key={detail.id} detail={detail} />;
+      case "column_list":
+        return <ColumnList key={detail.id} detail={detail} />;
+      case "column":
+        return <Column key={detail.id} detail={detail} />;
       default:
         console.warn("Unsupported Page Detail");
         console.log({ detail });
@@ -157,6 +161,36 @@ function Video({ detail }: { detail: VideoBlockObjectResponse }) {
         referrerPolicy="strict-origin-when-cross-origin"
         allowFullScreen
       />
+    </div>
+  );
+}
+
+function Column({ detail }: { detail: ColumnBlockObjectResponse }) {
+  // @ts-ignore
+  const children = detail.children.results;
+  const widthRatio = detail.column.width_ratio;
+
+  const getWidthClassName = () => {
+    if (widthRatio == 0.5) {
+      return "w-1/2";
+    }
+    return "";
+  };
+
+  return (
+    <div className={getWidthClassName()}>
+      <NotionPageDetails pageDetails={children} />
+    </div>
+  );
+}
+
+function ColumnList({ detail }: { detail: ColumnListBlockObjectResponse }) {
+  // @ts-ignore
+  const columns: BlockObjectResponse[] = detail.children.results;
+
+  return (
+    <div className="flex gap-2">
+      <NotionPageDetails pageDetails={columns} />
     </div>
   );
 }


### PR DESCRIPTION
## Remove Whitespace from Slugs
```js
const wrongSlug = 'good-block-to-window-air-sealing%20';
// Should be
const corrected = 'good-block-to-window-air-sealing';
```

## Notion Column Lists & Columns
It's good to have columns working in notion that way we can have more options when it comes to how we display and manage data.

Columns however aren't something that is synced over so this recursively syncs blocks that have children and puts them on a `children` attribute.